### PR TITLE
Show message code in lint messages

### DIFF
--- a/lib/linter-pep8.coffee
+++ b/lib/linter-pep8.coffee
@@ -47,4 +47,8 @@ class LinterPep8 extends Linter
 
     @cmd = cmd
 
+  formatMessage: (match) ->
+    code = match.error ? match.warning
+    "#{code} #{match.message}"
+
 module.exports = LinterPep8


### PR DESCRIPTION
This is useful because these ids are needed so you can turn off messages you
don't like. It also makes searching for more information about lint messages
easier.

In the future it'd be nice to be able to right click a lint message, click
'don't show again' and have linter-pylint update the project's pylintrc. But
this will do for now.

Test Plan:
Reloaded my Atom project and verified that ids are prepended to lint messages
