### PR TITLE
Fixing issue with pyenv complaining about missing pycodestyle

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,13 @@
 helpers = null
 
+# This function is from: https://atom.io/packages/linter-pylint
+getProjectDir = (filePath) ->
+  atomProject = atom.project.relativizePath(filePath)[0]
+  if atomProject == null
+    # Default project dirextory to file directory if path cannot be determined
+    return dirname(filePath)
+  return atomProject
+
 module.exports =
   config:
     executablePath:
@@ -35,7 +43,7 @@ module.exports =
           parameters.push("--ignore=#{ignoreCodes.join(',')}")
         parameters.push('-')
         msgtype = if atom.config.get('linter-pycodestyle.convertAllErrorsToWarnings') then 'Warning' else 'Error'
-        return helpers.exec(atom.config.get('linter-pycodestyle.executablePath'), parameters, {stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
+        return helpers.exec(atom.config.get('linter-pycodestyle.executablePath'), parameters, {cwd: getProjectDir(filePath), env: process.env, stdin: textEditor.getText(), ignoreExitCode: true}).then (result) ->
           toReturn = []
           regex = /stdin:(\d+):(\d+):(.*)/g
           while (match = regex.exec(result)) isnt null


### PR DESCRIPTION
It seems when using `pyenv` on OS X at least, that atom spawns child process in system root directory, which causes `pyenv` to determine there is no environment specified to given location.

Producing following output:
```
Error: pyenv: pycodestyle: command not found

The `pycodestyle' command exists in these Python versions: test_enviroment
Error: pyenv: pycodestyle: command not found
The `pycodestyle' command exists in these Python versions:
  tzk
    at ChildProcess.<anonymous> (/Users/sergej/.atom/packages/linter-pycodestyle/node_modules/sb-exec/lib/index.js:56:20)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at maybeClose (internal/child_process.js:877:16)
    at Socket.<anonymous> (internal/child_process.js:334:11)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at Pipe._handle.close [as _onclose] (net.js:493:12)
``` 

This change based on https://github.com/AtomLinter/linter-pylint/blob/master/lib/main.js passes all environment variables along with current file directory to fix aforementioned problem.