### PR TITLE
Use editor max line if user has not set a value

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -41,6 +41,8 @@ module.exports =
         parameters = []
         if maxLineLength = atom.config.get('linter-pycodestyle.maxLineLength')
           parameters.push("--max-line-length=#{maxLineLength}")
+        else if maxLineLength = atom.config.get('editor.preferredLineLength')
+          parameters.push("--max-line-length=#{maxLineLength}")
         if ignoreCodes = atom.config.get('linter-pycodestyle.ignoreErrorCodes')
           parameters.push("--ignore=#{ignoreCodes.join(',')}")
         parameters.push('-')


### PR DESCRIPTION
If the user does not set a value for maxLineLength in the package configuration then use the value set in the editor configuration.

Implements AtomLinter/linter-pycodestyle#94