### PR TITLE
Add specs

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,5 @@
+{
+  "max_line_length": {
+    "level": "ignore"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,12 +5,20 @@
   "description": "Linter plugin for pycodestyle",
   "repository": "https://github.com/AtomLinter/linter-pycodestyle",
   "license": "MIT",
+  "scripts": {
+    "test": "apm test",
+    "lint": "coffeelint ."
+  },
   "engines": {
     "atom": ">0.50.0"
   },
   "dependencies": {
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1"
+  },
+  "devDependencies": {
+    "jasmine-fix": "^1.0.1",
+    "coffeelint": "^1.9.7"
   },
   "package-deps": [
     "linter"

--- a/spec/fixtures/bad.py
+++ b/spec/fixtures/bad.py
@@ -1,0 +1,1 @@
+import os, path

--- a/spec/fixtures/good.py
+++ b/spec/fixtures/good.py
@@ -1,0 +1,1 @@
+"""Simple test file."""

--- a/spec/linter-pycodestyle-spec.js
+++ b/spec/linter-pycodestyle-spec.js
@@ -1,0 +1,56 @@
+'use babel';
+
+import { join } from 'path';
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
+
+const fixturePath = join(__dirname, 'fixtures');
+const goodPath = join(fixturePath, 'good.py');
+const badPath = join(fixturePath, 'bad.py');
+const emptyPath = join(fixturePath, 'empty.py');
+
+describe('The pycodestyle provider for Linter', () => {
+  const lint = require('../lib/main.coffee').provideLinter().lint;
+
+  beforeEach(async () => {
+    // Info about this beforeEach() implementation:
+    // https://github.com/AtomLinter/Meta/issues/15
+    const activationPromise = atom.packages.activatePackage('linter-pycodestyle');
+
+    await atom.packages.activatePackage('language-python');
+
+    atom.packages.triggerDeferredActivationHooks();
+    await activationPromise;
+  });
+
+  it('should be in the packages list', () =>
+    expect(atom.packages.isPackageLoaded('linter-pycodestyle')).toBe(true),
+  );
+
+  it('should be an active package', () =>
+    expect(atom.packages.isPackageActive('linter-pycodestyle')).toBe(true),
+  );
+
+  describe('checks bad.py and', () => {
+    let editor = null;
+    beforeEach(async () => {
+      editor = await atom.workspace.open(badPath);
+    });
+
+    it('verifies that message', async () => {
+      const messages = await lint(editor);
+      expect(messages[0].type).toBe('Warning');
+      expect(messages[0].html).not.toBeDefined();
+      expect(messages[0].text).toBe(' E401 multiple imports on one line');
+      expect(messages[0].filePath).toBe(badPath);
+      expect(messages[0].range).toEqual([[0, 9], [0, 10]]);
+    });
+  });
+
+  it('finds nothing wrong with a valid file', async () => {
+    const editor = await atom.workspace.open(goodPath);
+    const messages = await lint(editor);
+    expect(messages.length).toBe(0);
+  });
+
+});


### PR DESCRIPTION
Implement specs and add linter.

The specs were based on the specs from linter-flake8. Added `coffeelint` to the dev dependencies.

Now that the specs are implemented Travis can be enabled for this repository. If it is already enabled then it just a matter of adding the .travis.yml file.

Fix AtomLinter/linter-pycodestyle#42