### PR TITLE
Ignore editors with no path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,14 +37,14 @@ module.exports = {
   activate() {
     this.idleCallbacks = new Set();
     let depsCallbackID;
-    const installLinterJSHintDeps = () => {
+    const installLinterPycodestyleDeps = () => {
       this.idleCallbacks.delete(depsCallbackID);
       if (!atom.inSpecMode()) {
         require('atom-package-deps').install('linter-pycodestyle');
       }
       loadDeps();
     };
-    depsCallbackID = window.requestIdleCallback(installLinterJSHintDeps);
+    depsCallbackID = window.requestIdleCallback(installLinterPycodestyleDeps);
     this.idleCallbacks.add(depsCallbackID);
 
     this.subscriptions = new CompositeDisposable();
@@ -81,6 +81,10 @@ module.exports = {
       lintsOnChange: true,
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
+        if (!filePath) {
+          // Editor has no valid path, linting can't continue
+          return [];
+        }
         const fileContents = textEditor.getText();
 
         let projectPath = atom.project.relativizePath(filePath)[0];


### PR DESCRIPTION
If the given `TextEditor` has no path associated with it immediately return as we can't send results to Linter even though we could potentially get results.