### PR TITLE
Robustify the check for if ignoreCodes are set or not.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ module.exports = {
         if (this.maxLineLength) {
           parameters.push(`--max-line-length=${this.maxLineLength}`);
         }
-        if (this.ignoreCodes) {
+        if (this.ignoreCodes.length > 0) {
           parameters.push(`--ignore=${this.ignoreCodes.join(',')}`);
         }
         if (this.forcedConfig) {


### PR DESCRIPTION
The check for whether any ignore codes are set currently always evaluates to true.