### PR TITLE
Require path before usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,7 @@ module.exports = {
           return [];
         }
         const fileContents = textEditor.getText();
+        loadDeps();
 
         let projectPath = atom.project.relativizePath(filePath)[0];
         if (projectPath === null) {
@@ -105,8 +106,6 @@ module.exports = {
           parameters.push(`--config=${forcedConfigPath}`);
         }
         parameters.push('-');
-
-        loadDeps();
 
         const execOpts = {
           cwd: projectPath,


### PR DESCRIPTION
loadDeps() before using path.dirname (else path is undefined ...)